### PR TITLE
✨ Feat(shared): 라우팅 관련 유틸, 훅, 컴포넌트 분리 및 정리

### DIFF
--- a/src/shared/routes/components/index.ts
+++ b/src/shared/routes/components/index.ts
@@ -1,0 +1,1 @@
+export * from './router-link';

--- a/src/shared/routes/components/router-link.tsx
+++ b/src/shared/routes/components/router-link.tsx
@@ -1,0 +1,3 @@
+import RouterLink from "next/link";
+
+export { RouterLink };

--- a/src/shared/routes/hooks/index.ts
+++ b/src/shared/routes/hooks/index.ts
@@ -1,0 +1,10 @@
+export * from "./use-active-link";
+//
+
+export { useParams } from "./use-params";
+
+export { useRouter } from "./use-router";
+
+export { usePathname } from "./use-pathname";
+
+export { useSearchParams } from "./use-search-params";

--- a/src/shared/routes/hooks/use-params.ts
+++ b/src/shared/routes/hooks/use-params.ts
@@ -1,0 +1,1 @@
+export { useParams } from 'next/navigation';

--- a/src/shared/routes/hooks/use-pathname.ts
+++ b/src/shared/routes/hooks/use-pathname.ts
@@ -1,0 +1,1 @@
+export { usePathname } from "next/navigation";

--- a/src/shared/routes/hooks/use-router.ts
+++ b/src/shared/routes/hooks/use-router.ts
@@ -1,0 +1,1 @@
+export { useRouter } from 'next/navigation';

--- a/src/shared/routes/hooks/use-search-params.ts
+++ b/src/shared/routes/hooks/use-search-params.ts
@@ -1,0 +1,1 @@
+export { useSearchParams } from "next/navigation";

--- a/src/shared/routes/utils.ts
+++ b/src/shared/routes/utils.ts
@@ -1,0 +1,45 @@
+// ----------------------------------------------------------------------
+
+export const hasParams = (url: string): boolean => {
+  const queryString = url.split("?")[1];
+  return queryString
+    ? new URLSearchParams(queryString).toString().length > 0
+    : false;
+};
+
+// ----------------------------------------------------------------------
+
+export function removeLastSlash(pathname: string): string {
+  /**
+   * Remove last slash
+   * [1]
+   * @input  = '/slug/1/'
+   * @output = '/slug/1'
+   * [2]
+   * @input  = '/slug/1'
+   * @output = '/slug/1'
+   */
+  if (pathname !== "/" && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+
+  return pathname;
+}
+
+// ----------------------------------------------------------------------
+
+export function removeParams(url: string): string {
+  try {
+    const urlObj = new URL(url, window.location.origin);
+
+    return removeLastSlash(urlObj.pathname);
+  } catch (error) {
+    return url;
+  }
+}
+
+// ----------------------------------------------------------------------
+
+export function isExternalLink(url: string): boolean {
+  return url.startsWith("http");
+}


### PR DESCRIPTION

##  라우팅 관련 훅/유틸 정리 및 접근 레이어 분리

### 개요

라우팅 관련 기능을 정리하고, `next/navigation`에서 직접 훅을 사용하는 대신 **공통 hooks layer로 wrapping**하여 추상화했습니다.
이로 인해 **재사용성, 테스트 편의성, 라이브러리 변경 유연성** 확보가 가능합니다.

---

### 주요 변경 사항

#### 1. 📦 `src/shared/routes/hooks/*`

* `useRouter.ts`, `usePathname.ts`, `useSearchParams.ts`: `next/navigation` 훅을 래핑하여 export
* `index.ts`를 통해 통합 export

```ts
// before
import { useSearchParams } from "next/navigation";

// after
import { useSearchParams } from "@/shared/routes/hooks";
```

#### `src/shared/routes/utils.ts` 추가

* `hasParams(url: string)` : URL에 쿼리 스트링 존재 여부 확인
* `removeLastSlash(pathname: string)` : 마지막 슬래시 제거 유틸

---

### 추상화한 이유

```ts
export { useSearchParams } from "next/navigation";
```

이런 식으로 바로 사용하는 대신 wrapper 훅(`@/shared/routes/hooks`)을 두는 이유:

| 항목     | 설명                                                         |
| ------ | ---------------------------------------------------------- |
| ✅ 유지보수 | `next/navigation` → 다른 라우터로 마이그레이션 시, import 경로 한 번에 수정 가능 |
| ✅ 테스트  | 테스트 환경에서 mocking 또는 override가 쉬워짐                          |
| ✅ 공통화  | 커스텀 로직을 내부에 추가하거나 fallback 로직 삽입 가능                        |
| ✅ 일관성  | 전역적으로 동일한 방식으로 라우팅 관련 API 접근 보장                            |

---

###  테스트

* 각 훅의 정상 작동 확인 (`useSearchParams`, `useRouter`, `usePathname`)
* 쿼리 유틸 테스트 (`hasParams`, `removeLastSlash`)

