### PR TITLE
feat: 독서 기록 공개 여부 설정 단계(BookStep5) 추가

### DIFF
--- a/src/components/review/review-funnel.tsx
+++ b/src/components/review/review-funnel.tsx
@@ -12,6 +12,7 @@ import { LinearStepper } from "@/components/review/stepper";
 import { type InferredBookReviewSchema } from "@/schema/review-schema";
 import { useFunnel } from "@/shared/components/form/funnel";
 import BookStep4 from "./step4-form";
+import BookStep5 from "./step5-form";
 
 const STEPS = ["기본정보", "평가", "독후감", "인용구", "공개 여부"] as const;
 
@@ -59,6 +60,14 @@ const ReviewFunnel = () => {
     return createValidatedNextHandler(fieldsToValidate, trigger)();
   };
 
+  const handleSubmit = async () => {
+    const isValid = await trigger();
+    if (isValid) {
+      // 폼 제출 로직
+      console.log("폼 제출!");
+    }
+  };
+
   return (
     <Stack spacing={4}>
       {/* 진행 상태 표시 */}
@@ -103,6 +112,14 @@ const ReviewFunnel = () => {
           <Funnel.Navigation>
             <Funnel.Prev onClick={goPrevStep} />
             <Funnel.Next onClick={handleNextStep("인용구")} />
+          </Funnel.Navigation>
+        </Funnel.Step>
+
+        <Funnel.Step name="공개 여부">
+          <BookStep5 />
+          <Funnel.Navigation>
+            <Funnel.Prev onClick={goPrevStep} />
+            <Funnel.Next onClick={handleSubmit} label="제출" />
           </Funnel.Navigation>
         </Funnel.Step>
       </Funnel>

--- a/src/components/review/step5-form.tsx
+++ b/src/components/review/step5-form.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useFormContext, useWatch } from "react-hook-form";
+
+import { type InferredBookReviewSchema } from "@/schema/review-schema";
+import { RHFSwitch } from "@/shared/components/form/rhf-switch";
+import LockIcon from "@mui/icons-material/Lock";
+import PublicIcon from "@mui/icons-material/Public";
+import { Alert, Box, Card, Divider, Stack, Typography } from "@mui/material";
+
+const BookStep5 = () => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<InferredBookReviewSchema>();
+
+  const isPublic = useWatch({
+    control,
+    name: "isPublic",
+  });
+
+  return (
+    <Card sx={{ p: 3 }}>
+      <Stack spacing={3}>
+        <Stack spacing={2}>
+          <Typography variant="h6">🌍 공개 여부 설정</Typography>
+          <Typography variant="body2" color="text.secondary">
+            작성한 독서 기록을 다른 사람들과 공유할지 선택해주세요.
+          </Typography>
+        </Stack>
+
+        {/* 공개 여부 스위치 */}
+        <Card variant="outlined" sx={{ p: 3 }}>
+          <Stack spacing={3}>
+            <RHFSwitch
+              name="isPublic"
+              label="독서 기록 공개"
+              helperText={
+                errors.isPublic?.message ||
+                "공개로 설정하면 다른 사용자들이 내 독서 기록을 볼 수 있습니다."
+              }
+            />
+
+            <Divider />
+
+            {/* 공개/비공개 설명 */}
+            <Stack spacing={2}>
+              <Box
+                sx={{
+                  p: 2,
+                  borderRadius: 1,
+                  backgroundColor: isPublic ? "success.50" : "grey.50",
+                  border: "1px solid",
+                  borderColor: isPublic ? "success.200" : "grey.200",
+                }}
+              >
+                <Stack direction="row" spacing={2} alignItems="center">
+                  {isPublic ? (
+                    <PublicIcon color="success" />
+                  ) : (
+                    <LockIcon color="action" />
+                  )}
+                  <Stack spacing={1}>
+                    <Typography variant="subtitle2">
+                      {isPublic ? "🌍 공개 설정" : "🔒 비공개 설정"}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {isPublic
+                        ? "다른 사용자들이 내 독서 기록을 볼 수 있고, 검색 결과에도 표시됩니다."
+                        : "나만 볼 수 있으며, 다른 사용자들에게는 표시되지 않습니다."}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              </Box>
+
+              {/* 공개 시 추가 안내 */}
+              {isPublic && (
+                <Alert severity="info" sx={{ mt: 2 }}>
+                  <Typography variant="body2">
+                    <strong>공개 시 포함되는 정보:</strong>
+                    <br />
+                    • 도서 정보 (제목, 저자, 출판사)
+                    <br />
+                    • 별점 및 추천 여부
+                    <br />
+                    • 독후감 (작성한 경우)
+                    <br />
+                    • 인용구 (작성한 경우)
+                    <br />
+                    <br />
+                    개인정보(독서 시작/종료일 등)는 공개되지 않습니다.
+                  </Typography>
+                </Alert>
+              )}
+
+              {/* 비공개 시 추가 안내 */}
+              {!isPublic && (
+                <Alert severity="warning" sx={{ mt: 2 }}>
+                  <Typography variant="body2">
+                    <strong>비공개 설정:</strong>
+                    <br />
+                    나중에 언제든지 공개로 변경할 수 있습니다.
+                    <br />내 개인 독서 기록 페이지에서는 항상 모든 정보를 확인할
+                    수 있습니다.
+                  </Typography>
+                </Alert>
+              )}
+            </Stack>
+          </Stack>
+        </Card>
+
+        {/* 완료 안내 */}
+        <Box
+          sx={{
+            p: 3,
+            backgroundColor: "primary.50",
+            borderRadius: 1,
+            border: "1px solid",
+            borderColor: "primary.200",
+            textAlign: "center",
+          }}
+        >
+          <Typography variant="subtitle1" color="primary.main" gutterBottom>
+            🎉 독서 기록 작성이 거의 완료되었습니다!
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            "제출" 버튼을 눌러 독서 기록을 저장해주세요.
+          </Typography>
+        </Box>
+      </Stack>
+    </Card>
+  );
+};
+
+export default BookStep5;


### PR DESCRIPTION
<h3>개요</h3>
<p>책 리뷰 작성 마지막 단계에 <strong>공개 여부를 설정하는 BookStep5 컴포넌트</strong>를 추가했습니다.<br>
사용자는 작성한 독서 기록을 다른 사람들과 공유할지 여부를 선택할 수 있으며, 공개·비공개에 따른 안내를 명확하게 확인할 수 있습니다.</p>
<hr>
<h3>주요 변경사항</h3>

<ul>
<li>
<p><strong>공개 여부 스위치 추가 (<code inline="">RHFSwitch</code>)</strong></p>
<ul>
<li>
<p><code inline="">isPublic</code> 필드와 React Hook Form 연동</p>
</li>
<li>
<p>유효성 검증 및 헬퍼 텍스트 제공</p>
</li>
</ul>
</li>
<li>
<p><strong>UI 구성</strong></p>
<ul>
<li>
<p>공개/비공개 상태에 따라 아이콘 및 배경색 동적 변경</p>
</li>
<li>
<p>MUI <code inline="">Card</code>, <code inline="">Stack</code>, <code inline="">Alert</code> 등을 사용하여 직관적 레이아웃 구현</p>
</li>
</ul>
</li>
<li>
<p><strong>상태별 안내 메시지</strong></p>
<ul>
<li>
<p>공개(<code inline="">isPublic=true</code>) 시: 포함되는 정보 안내 (도서 정보, 별점, 독후감, 인용구)</p>
</li>
<li>
<p>비공개(<code inline="">isPublic=false</code>) 시: 개인 기록임을 안내 및 추후 변경 가능 메시지</p>
</li>
</ul>
</li>
<li>
<p><strong>완료 안내 영역</strong></p>
<ul>
<li>
<p>마지막 단계임을 강조하고 “제출” 버튼 클릭을 유도하는 메시지 추가</p>
</li>
</ul>
</li>
</ul>
<h4>🔧 구현 세부</h4>
<ul>
<li>
<p><code inline="">useWatch</code>로 <code inline="">isPublic</code> 상태를 구독하여 불필요한 리렌더링 방지</p>
</li>
<li>
<p>접근성을 고려한 명확한 라벨, 헬퍼 텍스트, 경고/정보 메시지 제공</p>
</li>
</ul>



### 스크린샷
<img width="922" height="657" alt="스크린샷 2025-07-20 오후 1 50 46" src="https://github.com/user-attachments/assets/198a725e-df1a-46a5-9e2d-79d2a8071d26" />
